### PR TITLE
Add a generic Dynamic type for db-specific columns

### DIFF
--- a/include/sqlgen/dynamic/Type.hpp
+++ b/include/sqlgen/dynamic/Type.hpp
@@ -13,7 +13,7 @@ using Type =
                      types::Float64, types::Int8, types::Int16, types::Int32,
                      types::Int64, types::UInt8, types::UInt16, types::UInt32,
                      types::UInt64, types::Text, types::Date, types::Timestamp,
-                     types::TimestampWithTZ, types::VarChar>;
+                     types::TimestampWithTZ, types::VarChar, types::Dynamic>;
 
 }  // namespace sqlgen::dynamic
 

--- a/include/sqlgen/dynamic/types.hpp
+++ b/include/sqlgen/dynamic/types.hpp
@@ -93,6 +93,11 @@ struct VarChar {
   Properties properties;
 };
 
+struct Dynamic {
+  std::string type_name;
+  Properties properties;
+};
+
 }  // namespace sqlgen::dynamic::types
 
 #endif

--- a/src/sqlgen/mysql/to_sql.cpp
+++ b/src/sqlgen/mysql/to_sql.cpp
@@ -865,6 +865,8 @@ std::string type_to_sql(const dynamic::Type& _type) noexcept {
     } else if constexpr (std::is_same_v<T, dynamic::types::Timestamp> ||
                          std::is_same_v<T, dynamic::types::TimestampWithTZ>) {
       return "DATETIME";
+    } else if constexpr (std::is_same_v<T, dynamic::types::Dynamic>) {
+      return _t.type_name;
 
     } else if constexpr (std::is_same_v<T, dynamic::types::Unknown>) {
       return "TEXT";

--- a/src/sqlgen/postgres/to_sql.cpp
+++ b/src/sqlgen/postgres/to_sql.cpp
@@ -751,9 +751,11 @@ std::string type_to_sql(const dynamic::Type& _type) noexcept {
     } else if constexpr (std::is_same_v<T, dynamic::types::TimestampWithTZ>) {
       return "TIMESTAMP WITH TIME ZONE";
 
+    } else if constexpr (std::is_same_v<T, dynamic::types::Dynamic>) {
+      return _t.type_name;
+
     } else if constexpr (std::is_same_v<T, dynamic::types::Unknown>) {
       return "TEXT";
-
     } else {
       static_assert(rfl::always_false_v<T>, "Not all cases were covered.");
     }

--- a/src/sqlgen/sqlite/to_sql.cpp
+++ b/src/sqlgen/sqlite/to_sql.cpp
@@ -740,6 +740,8 @@ std::string type_to_sql(const dynamic::Type& _type) noexcept {
                          std::is_same_v<T, dynamic::types::Timestamp> ||
                          std::is_same_v<T, dynamic::types::TimestampWithTZ>) {
       return "TEXT";
+    } else if constexpr (std::is_same_v<T, dynamic::types::Dynamic>) {
+      return _t.type_name;
     } else {
       static_assert(rfl::always_false_v<T>, "Not all cases were covered.");
     }


### PR DESCRIPTION
This allows a "catch-all" dynamic type which can be used with arbitrary column types. In my example posted [here](https://github.com/getml/sqlgen/issues/41#issuecomment-3204554825) , you can simply change the Parser specialization for `boost::uuids::uuid`:
```cpp
namespace sqlgen::parsing {
template <>
struct Parser<boost::uuids::uuid> {
  using Type = boost::uuids::uuid;

  static Result<boost::uuids::uuid> read(
      const std::optional<std::string>& _str) noexcept {
  ...
  }

  static std::optional<std::string> write(
  ...
  }

  static dynamic::Type to_type() noexcept {
    return sqlgen::dynamic::types::Dynamic{"UUID"};
  };
};
```
It would be the responsibility of the user to make sure that the given `type_name` is valid in the chosen database. Based on my current understanding of the code, this information is not available at compile-time (at the point where `sqlgen::parsing::Parser<custom_type>::to_type()` is called).

Resolves #41.

Relates to #42 (closed due to new pushes on my main).