### PR TITLE
Add enum support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vcpkg"]
 	path = vcpkg
-	url = git@github.com:microsoft/vcpkg.git
+	url = https://github.com/microsoft/vcpkg.git

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ Welcome to the sqlgen documentation. This guide provides detailed information ab
 - [Type Conversion Operations](type_conversion_operations.md) - How to convert between types safely in queries (e.g., cast int to double).
 - [Null Handling Operations](null_handling_operations.md) - How to handle nullable values and propagate nullability correctly (e.g., with coalesce and nullability rules).
 - [Timestamp and Date/Time Functions](timestamp_operations.md) - How to work with timestamps, dates, and times (e.g., extract parts, perform arithmetic, convert formats).
+- [Enums](enum.md) - How to work with enums sqlgen
 
 ## Data Types and Validation
 

--- a/docs/enum.md
+++ b/docs/enum.md
@@ -1,0 +1,37 @@
+# `Enums`
+
+Enums can directly be used in sqlgen structs. They are mapped to native enum types in PostgreSQL and MySQL. In sqlite, which does not support native enum types, they are stored as `TEXT` by default.
+
+## Usage
+
+### Basic Definition
+
+```cpp
+enum class Color : int { RED = 1, GREEN = 2, BLUE = 3 };
+struct Flower {
+    sqlgen::PrimaryKey<std::string> name;
+    Color color;
+}
+
+const auto red_rose = Flower{
+    .name = "Rose",
+    .color = Color::RED,
+};
+```
+
+This generates the following SQL schema:
+```sql
+CREATE TYPE IF NOT EXISTS "Color" AS ENUM ('RED', 'GREEN', 'BLUE');
+CREATE TABLE IF NOT EXISTS "Flower"(
+    "name"  TEXT NOT NULL,
+    "color" Color NOT NULL,
+    PRIMARY_KEY("name")
+);
+```
+
+## Notes
+- Due to naming restrictions in PostgreSQL, the namespace operator `::` is replaced with `__`. Thus, an enum defined as `namespace1::some_struct::MyEnum` will be created in the database as `namespace1__some_struct__MyEnum`. This mangled name can at most be 63 characters long.
+- Enums are specific types in PostgreSQL. They are only created once and shared between tables.
+- In MySQL, enums are stored as native types but they are not shared between tables.
+- In sqlite, enums are stored as `TEXT` by default. If you need to use integers, you can specialize the `Parser<T>` struct as explained [here](dynamic.md).
+- You can use `rfl::enum_to_string` and `rfl::string_to_enum` to convert between enum values and their string representations.

--- a/include/sqlgen/dynamic/Type.hpp
+++ b/include/sqlgen/dynamic/Type.hpp
@@ -14,7 +14,7 @@ using Type =
                      types::Int32, types::Int64, types::JSON, types::UInt8,
                      types::UInt16, types::UInt32, types::UInt64, types::Text,
                      types::Date, types::Timestamp, types::TimestampWithTZ,
-                     types::VarChar>;
+                     types::VarChar, types::Enum>;
 
 }  // namespace sqlgen::dynamic
 

--- a/include/sqlgen/dynamic/types.hpp
+++ b/include/sqlgen/dynamic/types.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace sqlgen::dynamic::types {
 
@@ -75,6 +76,12 @@ struct UInt32 {
 };
 
 struct UInt64 {
+  Properties properties;
+};
+
+struct Enum {
+  std::string name;
+  std::vector<std::string> values;
   Properties properties;
 };
 

--- a/include/sqlgen/transpilation/to_value.hpp
+++ b/include/sqlgen/transpilation/to_value.hpp
@@ -25,6 +25,9 @@ dynamic::Value to_value(const T& _t) {
   } else if constexpr (has_reflection_method<Type>) {
     return to_value(_t.reflection());
 
+  } else if constexpr (std::is_enum_v<Type>) {
+    return dynamic::Value{dynamic::String{.val = rfl::enum_to_string(_t)}};
+
   } else {
     static_assert(rfl::always_false_v<T>, "Unsupported type");
   }

--- a/src/sqlgen/mysql/to_sql.cpp
+++ b/src/sqlgen/mysql/to_sql.cpp
@@ -82,6 +82,10 @@ inline std::string wrap_in_quotes(const std::string& _name) noexcept {
   return "`" + _name + "`";
 }
 
+inline std::string wrap_in_single_quotes(const std::string& _name) noexcept {
+  return "'" + _name + "'";
+}
+
 // ----------------------------------------------------------------------------
 
 std::string aggregation_to_sql(
@@ -154,6 +158,8 @@ std::string cast_type_to_sql(const dynamic::Type& _type) noexcept {
     } else if constexpr (std::is_same_v<T, dynamic::types::Unknown>) {
       return "CHAR";
 
+    } else if constexpr (std::is_same_v<T, dynamic::types::Enum>) {
+      return "ENUM";
     } else {
       static_assert(rfl::always_false_v<T>, "Not all cases were covered.");
     }
@@ -871,6 +877,14 @@ std::string type_to_sql(const dynamic::Type& _type) noexcept {
                          std::is_same_v<T, dynamic::types::Int64> ||
                          std::is_same_v<T, dynamic::types::UInt64>) {
       return "BIGINT";
+
+    } else if constexpr (std::is_same_v<T, dynamic::types::Enum>) {
+      return "ENUM(" +
+             internal::strings::join(
+                 ", ", internal::collect::vector(_t.values |
+                                                 std::ranges::views::transform(
+                                                     wrap_in_single_quotes))) +
+             ")";
 
     } else if constexpr (std::is_same_v<T, dynamic::types::Float32> ||
                          std::is_same_v<T, dynamic::types::Float64>) {

--- a/src/sqlgen/sqlite/to_sql.cpp
+++ b/src/sqlgen/sqlite/to_sql.cpp
@@ -769,7 +769,8 @@ std::string type_to_sql(const dynamic::Type& _type) noexcept {
 
     } else if constexpr (std::is_same_v<T, dynamic::types::Dynamic>) {
       return _t.type_name;
-
+    } else if constexpr (std::is_same_v<T, dynamic::types::Enum>) {
+      return "TEXT";
     } else {
       static_assert(rfl::always_false_v<T>, "Not all cases were covered.");
     }

--- a/tests/mysql/test_enum_crosstable.cpp
+++ b/tests/mysql/test_enum_crosstable.cpp
@@ -1,0 +1,107 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <sqlgen.hpp>
+#include <sqlgen/mysql.hpp>
+#include <vector>
+
+namespace test_enum_cross_table {
+enum class AccessRestriction { PUBLIC = 1, INTERNAL = 2, CONFIDENTIAL = 3 };
+struct Employee {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  std::string first_name;
+  std::string last_name;
+  AccessRestriction access_level;
+};
+
+struct Document {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  AccessRestriction min_access_level;
+  std::string name;
+  std::string path;
+};
+
+TEST(mysql, test_enum_cross_table) {
+  using namespace sqlgen;
+  using namespace sqlgen::literals;
+
+  auto employees = std::vector<Employee>({
+      Employee{.first_name = "Homer",
+               .last_name = "Simpson",
+               .access_level = AccessRestriction::PUBLIC},
+      Employee{.first_name = "Waylon",
+               .last_name = "Smithers",
+               .access_level = AccessRestriction::INTERNAL},
+      Employee{.first_name = "Montgomery",
+               .last_name = "Burns",
+               .access_level = AccessRestriction::CONFIDENTIAL},
+  });
+  auto documents = std::vector<Document>({
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Power Plant Safety Manual",
+               .path = "/documents/powerplant/safety_manual.txt"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Staff Memo",
+               .path = "/documents/powerplant/staff_memo.txt"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Operations Report",
+               .path = "/documents/powerplant/operations_report.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Project Plan",
+               .path = "/documents/powerplant/project_plan.md"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Budget Q1",
+               .path = "/documents/powerplant/budget_q1.pdf"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "HR Policies",
+               .path = "/documents/powerplant/hr_policies.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Team Photo",
+               .path = "/documents/powerplant/team.jpg"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Executive Summary",
+               .path = "/documents/powerplant/executive_summary.docx"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Release Notes",
+               .path = "/documents/powerplant/release_notes.txt"},
+  });
+
+  const auto credentials = sqlgen::mysql::Credentials{.host = "localhost",
+                                                      .user = "sqlgen",
+                                                      .password = "password",
+                                                      .dbname = "mysql"};
+  const auto conn = mysql::connect(credentials);
+  conn.and_then(drop<Employee> | if_exists)
+      .and_then(drop<Document> | if_exists);
+
+  write(conn, employees);
+  write(conn, documents);
+
+  const auto smithers = conn.and_then(sqlgen::read<Employee> |
+                                      where("last_name"_c == "Smithers" and
+                                            "first_name"_c == "Waylon"))
+                            .value();
+
+  const auto smithers_level = smithers.access_level;
+  const auto smithers_documents =
+      conn.and_then(sqlgen::read<std::vector<Document>> |
+                    where("min_access_level"_c == smithers_level ||
+                          "min_access_level"_c == AccessRestriction::PUBLIC) |
+                    order_by("name"_c))
+          .value();
+
+  const auto expected_ids = std::set<uint32_t>{1, 2, 4, 5, 7, 9};
+  std::set<uint32_t> actual_ids;
+  for (const auto &d : smithers_documents) {
+    actual_ids.emplace(d.id());
+  }
+
+  EXPECT_EQ(expected_ids, actual_ids);
+}
+
+}  // namespace test_enum_cross_table
+
+#endif

--- a/tests/mysql/test_enum_lookup.cpp
+++ b/tests/mysql/test_enum_lookup.cpp
@@ -1,0 +1,91 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <sqlgen.hpp>
+#include <sqlgen/mysql.hpp>
+#include <vector>
+
+namespace test_enum_lookup {
+
+enum class AccessRestriction { PUBLIC = 1, INTERNAL = 2, CONFIDENTIAL = 3 };
+struct Document {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  AccessRestriction min_access_level;
+  std::string name;
+  std::string path;
+};
+
+TEST(mysql, test_enum_lookup) {
+  auto documents = std::vector<Document>({
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Power Plant Safety Manual",
+               .path = "/documents/powerplant/safety_manual.txt"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Staff Memo",
+               .path = "/documents/powerplant/staff_memo.txt"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Operations Report",
+               .path = "/documents/powerplant/operations_report.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Project Plan",
+               .path = "/documents/powerplant/project_plan.md"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Budget Q1",
+               .path = "/documents/powerplant/budget_q1.pdf"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "HR Policies",
+               .path = "/documents/powerplant/hr_policies.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Team Photo",
+               .path = "/documents/powerplant/team.jpg"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Executive Summary",
+               .path = "/documents/powerplant/executive_summary.docx"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Release Notes",
+               .path = "/documents/powerplant/release_notes.txt"},
+  });
+
+  const auto credentials = sqlgen::mysql::Credentials{.host = "localhost",
+                                                      .user = "sqlgen",
+                                                      .password = "password",
+                                                      .dbname = "mysql"};
+
+  using namespace sqlgen;
+  using namespace sqlgen::literals;
+
+  const auto public_documents =
+      mysql::connect(credentials)
+          .and_then(drop<Document> | if_exists)
+          .and_then(write(std::ref(documents)))
+          .and_then(sqlgen::read<std::vector<Document>> |
+                    where("min_access_level"_c == AccessRestriction::PUBLIC) |
+                    order_by("name"_c.desc()))
+          .value();
+
+  const auto expected = std::vector<Document>({
+      Document{.id = 7,
+               .min_access_level = AccessRestriction::PUBLIC,
+               .name = "Team Photo",
+               .path = "/documents/powerplant/team.jpg"},
+      Document{.id = 4,
+               .min_access_level = AccessRestriction::PUBLIC,
+               .name = "Project Plan",
+               .path = "/documents/powerplant/project_plan.md"},
+      Document{.id = 1,
+               .min_access_level = AccessRestriction::PUBLIC,
+               .name = "Power Plant Safety Manual",
+               .path = "/documents/powerplant/safety_manual.txt"},
+  });
+
+  const auto json1 = rfl::json::write(expected);
+  const auto json2 = rfl::json::write(public_documents);
+  EXPECT_EQ(json1, json2);
+}
+
+}  // namespace test_enum_lookup
+
+#endif

--- a/tests/mysql/test_enum_namespace.cpp
+++ b/tests/mysql/test_enum_namespace.cpp
@@ -1,0 +1,66 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <sqlgen.hpp>
+#include <sqlgen/mysql.hpp>
+#include <vector>
+
+namespace test_enum_namespace {
+namespace first {
+enum class IdenticallyNamed { VALUE0, VALUE1, VALUE2 };
+
+}
+namespace second {
+enum class IdenticallyNamed { VALUE3, VALUE4, VALUE5 };
+}
+
+struct MultiStruct {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  first::IdenticallyNamed enum_one;
+  second::IdenticallyNamed enum_two;
+};
+
+TEST(mysql, test_enum_namespace) {
+  using namespace sqlgen;
+  using namespace sqlgen::literals;
+
+  auto objects = std::vector<MultiStruct>({
+      MultiStruct{.enum_one = first::IdenticallyNamed::VALUE0,
+                  .enum_two = second::IdenticallyNamed::VALUE3},
+      MultiStruct{.enum_one = first::IdenticallyNamed::VALUE1,
+                  .enum_two = second::IdenticallyNamed::VALUE4},
+      MultiStruct{.enum_one = first::IdenticallyNamed::VALUE2,
+                  .enum_two = second::IdenticallyNamed::VALUE5},
+  });
+
+  const auto credentials = sqlgen::mysql::Credentials{.host = "localhost",
+                                                      .user = "sqlgen",
+                                                      .password = "password",
+                                                      .dbname = "mysql"};
+  const auto conn = mysql::connect(credentials);
+  conn.and_then(drop<MultiStruct> | if_exists);
+
+  write(conn, objects);
+
+  const auto read_objects =
+      sqlgen::read<std::vector<MultiStruct>>(conn).value();
+  std::vector<uint32_t> actual_ids;
+  for (const auto& obj : read_objects) {
+    if (obj.enum_one == first::IdenticallyNamed::VALUE0) {
+      EXPECT_EQ(obj.enum_two, second::IdenticallyNamed::VALUE3);
+    } else if (obj.enum_one == first::IdenticallyNamed::VALUE1) {
+      EXPECT_EQ(obj.enum_two, second::IdenticallyNamed::VALUE4);
+    } else if (obj.enum_one == first::IdenticallyNamed::VALUE2) {
+      EXPECT_EQ(obj.enum_two, second::IdenticallyNamed::VALUE5);
+    } else {
+      FAIL() << "Unexpected enum value";
+    }
+  }
+}
+
+}  // namespace test_enum_namespace
+
+#endif

--- a/tests/postgres/test_enum_crosstable.cpp
+++ b/tests/postgres/test_enum_crosstable.cpp
@@ -1,0 +1,108 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <sqlgen.hpp>
+#include <sqlgen/postgres.hpp>
+#include <vector>
+
+namespace test_enum_cross_table {
+enum class AccessRestriction { PUBLIC = 1, INTERNAL = 2, CONFIDENTIAL = 3 };
+struct Employee {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  std::string first_name;
+  std::string last_name;
+  AccessRestriction access_level;
+};
+
+struct Document {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  AccessRestriction min_access_level;
+  std::string name;
+  std::string path;
+};
+
+TEST(postgres, test_enum_cross_table) {
+  using namespace sqlgen;
+  using namespace sqlgen::literals;
+
+  auto employees = std::vector<Employee>({
+      Employee{.first_name = "Homer",
+               .last_name = "Simpson",
+               .access_level = AccessRestriction::PUBLIC},
+      Employee{.first_name = "Waylon",
+               .last_name = "Smithers",
+               .access_level = AccessRestriction::INTERNAL},
+      Employee{.first_name = "Montgomery",
+               .last_name = "Burns",
+               .access_level = AccessRestriction::CONFIDENTIAL},
+  });
+  auto documents = std::vector<Document>({
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Power Plant Safety Manual",
+               .path = "/documents/powerplant/safety_manual.txt"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Staff Memo",
+               .path = "/documents/powerplant/staff_memo.txt"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Operations Report",
+               .path = "/documents/powerplant/operations_report.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Project Plan",
+               .path = "/documents/powerplant/project_plan.md"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Budget Q1",
+               .path = "/documents/powerplant/budget_q1.pdf"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "HR Policies",
+               .path = "/documents/powerplant/hr_policies.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Team Photo",
+               .path = "/documents/powerplant/team.jpg"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Executive Summary",
+               .path = "/documents/powerplant/executive_summary.docx"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Release Notes",
+               .path = "/documents/powerplant/release_notes.txt"},
+  });
+
+  const auto credentials = sqlgen::postgres::Credentials{.user = "postgres",
+                                                         .password = "password",
+                                                         .host = "localhost",
+                                                         .dbname = "postgres"};
+  const auto conn = postgres::connect(credentials);
+  conn.and_then(drop<Employee> | if_exists)
+      .and_then(drop<Document> | if_exists);
+
+  write(conn, employees);
+  write(conn, documents);
+
+  const auto smithers = conn.and_then(sqlgen::read<Employee> |
+                                      where("last_name"_c == "Smithers" and
+                                            "first_name"_c == "Waylon"))
+                            .value();
+  // EXPECT_FALSE(smithers.empty());
+
+  const auto smithers_level = smithers.access_level;
+  const auto smithers_documents =
+      conn.and_then(sqlgen::read<std::vector<Document>> |
+                    where("min_access_level"_c == smithers_level ||
+                          "min_access_level"_c == AccessRestriction::PUBLIC) |
+                    order_by("name"_c))
+          .value();
+
+  const auto expected_ids = std::set<uint32_t>{1, 2, 4, 5, 7, 9};
+  std::set<uint32_t> actual_ids;
+  for (const auto &d : smithers_documents) {
+    actual_ids.emplace(d.id());
+  }
+
+  EXPECT_EQ(expected_ids, actual_ids);
+}
+
+}  // namespace test_enum_cross_table
+
+#endif

--- a/tests/postgres/test_enum_lookup.cpp
+++ b/tests/postgres/test_enum_lookup.cpp
@@ -1,0 +1,91 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <sqlgen.hpp>
+#include <sqlgen/postgres.hpp>
+#include <vector>
+
+namespace test_enum_lookup {
+
+enum class AccessRestriction { PUBLIC = 1, INTERNAL = 2, CONFIDENTIAL = 3 };
+struct Document {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  AccessRestriction min_access_level;
+  std::string name;
+  std::string path;
+};
+
+TEST(postgres, test_enum_lookup) {
+  auto documents = std::vector<Document>({
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Power Plant Safety Manual",
+               .path = "/documents/powerplant/safety_manual.txt"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Staff Memo",
+               .path = "/documents/powerplant/staff_memo.txt"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Operations Report",
+               .path = "/documents/powerplant/operations_report.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Project Plan",
+               .path = "/documents/powerplant/project_plan.md"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Budget Q1",
+               .path = "/documents/powerplant/budget_q1.pdf"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "HR Policies",
+               .path = "/documents/powerplant/hr_policies.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Team Photo",
+               .path = "/documents/powerplant/team.jpg"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Executive Summary",
+               .path = "/documents/powerplant/executive_summary.docx"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Release Notes",
+               .path = "/documents/powerplant/release_notes.txt"},
+  });
+
+  const auto credentials = sqlgen::postgres::Credentials{.user = "postgres",
+                                                         .password = "password",
+                                                         .host = "localhost",
+                                                         .dbname = "postgres"};
+
+  using namespace sqlgen;
+  using namespace sqlgen::literals;
+
+  const auto public_documents =
+      postgres::connect(credentials)
+          .and_then(drop<Document> | if_exists)
+          .and_then(write(std::ref(documents)))
+          .and_then(sqlgen::read<std::vector<Document>> |
+                    where("min_access_level"_c == AccessRestriction::PUBLIC) |
+                    order_by("name"_c.desc()))
+          .value();
+
+  const auto expected = std::vector<Document>({
+      Document{.id = 7,
+               .min_access_level = AccessRestriction::PUBLIC,
+               .name = "Team Photo",
+               .path = "/documents/powerplant/team.jpg"},
+      Document{.id = 4,
+               .min_access_level = AccessRestriction::PUBLIC,
+               .name = "Project Plan",
+               .path = "/documents/powerplant/project_plan.md"},
+      Document{.id = 1,
+               .min_access_level = AccessRestriction::PUBLIC,
+               .name = "Power Plant Safety Manual",
+               .path = "/documents/powerplant/safety_manual.txt"},
+  });
+
+  const auto json1 = rfl::json::write(expected);
+  const auto json2 = rfl::json::write(public_documents);
+  EXPECT_EQ(json1, json2);
+}
+
+}  // namespace test_enum_lookup
+
+#endif

--- a/tests/postgres/test_enum_namespace.cpp
+++ b/tests/postgres/test_enum_namespace.cpp
@@ -1,0 +1,66 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <sqlgen.hpp>
+#include <sqlgen/postgres.hpp>
+#include <vector>
+
+namespace test_enum_namespace {
+namespace first {
+enum class IdenticallyNamed { VALUE0, VALUE1, VALUE2 };
+
+}
+namespace second {
+enum class IdenticallyNamed { VALUE3, VALUE4, VALUE5 };
+}
+
+struct MultiStruct {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  first::IdenticallyNamed enum_one;
+  second::IdenticallyNamed enum_two;
+};
+
+TEST(mysql, test_enum_namespace) {
+  using namespace sqlgen;
+  using namespace sqlgen::literals;
+
+  auto objects = std::vector<MultiStruct>({
+      MultiStruct{.enum_one = first::IdenticallyNamed::VALUE0,
+                  .enum_two = second::IdenticallyNamed::VALUE3},
+      MultiStruct{.enum_one = first::IdenticallyNamed::VALUE1,
+                  .enum_two = second::IdenticallyNamed::VALUE4},
+      MultiStruct{.enum_one = first::IdenticallyNamed::VALUE2,
+                  .enum_two = second::IdenticallyNamed::VALUE5},
+  });
+
+  const auto credentials = sqlgen::postgres::Credentials{.user = "postgres",
+                                                         .password = "password",
+                                                         .host = "localhost",
+                                                         .dbname = "postgres"};
+  const auto conn = postgres::connect(credentials);
+  conn.and_then(drop<MultiStruct> | if_exists);
+
+  write(conn, objects);
+
+  const auto read_objects =
+      sqlgen::read<std::vector<MultiStruct>>(conn).value();
+  std::vector<uint32_t> actual_ids;
+  for (const auto& obj : read_objects) {
+    if (obj.enum_one == first::IdenticallyNamed::VALUE0) {
+      EXPECT_EQ(obj.enum_two, second::IdenticallyNamed::VALUE3);
+    } else if (obj.enum_one == first::IdenticallyNamed::VALUE1) {
+      EXPECT_EQ(obj.enum_two, second::IdenticallyNamed::VALUE4);
+    } else if (obj.enum_one == first::IdenticallyNamed::VALUE2) {
+      EXPECT_EQ(obj.enum_two, second::IdenticallyNamed::VALUE5);
+    } else {
+      FAIL() << "Unexpected enum value";
+    }
+  }
+}
+
+}  // namespace test_enum_namespace
+
+#endif

--- a/tests/sqlite/test_enum_crosstable.cpp
+++ b/tests/sqlite/test_enum_crosstable.cpp
@@ -1,0 +1,103 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <sqlgen.hpp>
+#include <sqlgen/sqlite.hpp>
+#include <vector>
+
+namespace test_enum_cross_table {
+enum class AccessRestriction { PUBLIC = 1, INTERNAL = 2, CONFIDENTIAL = 3 };
+struct Employee {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  std::string first_name;
+  std::string last_name;
+  AccessRestriction access_level;
+};
+
+struct Document {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  AccessRestriction min_access_level;
+  std::string name;
+  std::string path;
+};
+
+TEST(sqlite, test_enum_cross_table) {
+  using namespace sqlgen;
+  using namespace sqlgen::literals;
+
+  auto employees = std::vector<Employee>({
+      Employee{.first_name = "Homer",
+               .last_name = "Simpson",
+               .access_level = AccessRestriction::PUBLIC},
+      Employee{.first_name = "Waylon",
+               .last_name = "Smithers",
+               .access_level = AccessRestriction::INTERNAL},
+      Employee{.first_name = "Montgomery",
+               .last_name = "Burns",
+               .access_level = AccessRestriction::CONFIDENTIAL},
+  });
+  auto documents = std::vector<Document>({
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Power Plant Safety Manual",
+               .path = "/documents/powerplant/safety_manual.txt"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Staff Memo",
+               .path = "/documents/powerplant/staff_memo.txt"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Operations Report",
+               .path = "/documents/powerplant/operations_report.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Project Plan",
+               .path = "/documents/powerplant/project_plan.md"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Budget Q1",
+               .path = "/documents/powerplant/budget_q1.pdf"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "HR Policies",
+               .path = "/documents/powerplant/hr_policies.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Team Photo",
+               .path = "/documents/powerplant/team.jpg"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Executive Summary",
+               .path = "/documents/powerplant/executive_summary.docx"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Release Notes",
+               .path = "/documents/powerplant/release_notes.txt"},
+  });
+
+  const auto conn = sqlite::connect();
+  conn.and_then(drop<Employee> | if_exists)
+      .and_then(drop<Document> | if_exists);
+
+  write(conn, employees);
+  write(conn, documents);
+
+  const auto smithers = conn.and_then(sqlgen::read<Employee> |
+                                      where("last_name"_c == "Smithers" and
+                                            "first_name"_c == "Waylon"))
+                            .value();
+
+  const auto smithers_level = smithers.access_level;
+  const auto smithers_documents =
+      conn.and_then(sqlgen::read<std::vector<Document>> |
+                    where("min_access_level"_c == smithers_level ||
+                          "min_access_level"_c == AccessRestriction::PUBLIC) |
+                    order_by("name"_c))
+          .value();
+
+  const auto expected_ids = std::set<uint32_t>{1, 2, 4, 5, 7, 9};
+  std::set<uint32_t> actual_ids;
+  for (const auto &d : smithers_documents) {
+    actual_ids.emplace(d.id());
+  }
+
+  EXPECT_EQ(expected_ids, actual_ids);
+}
+
+}  // namespace test_enum_cross_table
+
+#endif

--- a/tests/sqlite/test_enum_lookup.cpp
+++ b/tests/sqlite/test_enum_lookup.cpp
@@ -1,0 +1,86 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <sqlgen.hpp>
+#include <sqlgen/sqlite.hpp>
+#include <vector>
+
+namespace test_enum_lookup {
+
+enum class AccessRestriction { PUBLIC = 1, INTERNAL = 2, CONFIDENTIAL = 3 };
+struct Document {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  AccessRestriction min_access_level;
+  std::string name;
+  std::string path;
+};
+
+TEST(sqlite, test_enum_lookup) {
+  auto documents = std::vector<Document>({
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Power Plant Safety Manual",
+               .path = "/documents/powerplant/safety_manual.txt"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Staff Memo",
+               .path = "/documents/powerplant/staff_memo.txt"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Operations Report",
+               .path = "/documents/powerplant/operations_report.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Project Plan",
+               .path = "/documents/powerplant/project_plan.md"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Budget Q1",
+               .path = "/documents/powerplant/budget_q1.pdf"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "HR Policies",
+               .path = "/documents/powerplant/hr_policies.pdf"},
+      Document{.min_access_level = AccessRestriction::PUBLIC,
+               .name = "Team Photo",
+               .path = "/documents/powerplant/team.jpg"},
+      Document{.min_access_level = AccessRestriction::CONFIDENTIAL,
+               .name = "Executive Summary",
+               .path = "/documents/powerplant/executive_summary.docx"},
+      Document{.min_access_level = AccessRestriction::INTERNAL,
+               .name = "Release Notes",
+               .path = "/documents/powerplant/release_notes.txt"},
+  });
+
+  using namespace sqlgen;
+  using namespace sqlgen::literals;
+
+  const auto public_documents =
+      sqlite::connect()
+          .and_then(drop<Document> | if_exists)
+          .and_then(write(std::ref(documents)))
+          .and_then(sqlgen::read<std::vector<Document>> |
+                    where("min_access_level"_c == AccessRestriction::PUBLIC) |
+                    order_by("name"_c.desc()))
+          .value();
+
+  const auto expected = std::vector<Document>({
+      Document{.id = 7,
+               .min_access_level = AccessRestriction::PUBLIC,
+               .name = "Team Photo",
+               .path = "/documents/powerplant/team.jpg"},
+      Document{.id = 4,
+               .min_access_level = AccessRestriction::PUBLIC,
+               .name = "Project Plan",
+               .path = "/documents/powerplant/project_plan.md"},
+      Document{.id = 1,
+               .min_access_level = AccessRestriction::PUBLIC,
+               .name = "Power Plant Safety Manual",
+               .path = "/documents/powerplant/safety_manual.txt"},
+  });
+
+  const auto json1 = rfl::json::write(expected);
+  const auto json2 = rfl::json::write(public_documents);
+  EXPECT_EQ(json1, json2);
+}
+
+}  // namespace test_enum_lookup
+
+#endif

--- a/tests/sqlite/test_enum_namespace.cpp
+++ b/tests/sqlite/test_enum_namespace.cpp
@@ -1,0 +1,62 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <rfl.hpp>
+#include <rfl/json.hpp>
+#include <sqlgen.hpp>
+#include <sqlgen/sqlite.hpp>
+#include <vector>
+
+namespace test_enum_namespace {
+namespace first {
+enum class IdenticallyNamed { VALUE0, VALUE1, VALUE2 };
+
+}
+namespace second {
+enum class IdenticallyNamed { VALUE3, VALUE4, VALUE5 };
+}
+
+struct MultiStruct {
+  sqlgen::PrimaryKey<uint32_t, sqlgen::auto_incr> id;
+  first::IdenticallyNamed enum_one;
+  second::IdenticallyNamed enum_two;
+};
+
+TEST(mysql, test_enum_namespace) {
+  using namespace sqlgen;
+  using namespace sqlgen::literals;
+
+  auto objects = std::vector<MultiStruct>({
+      MultiStruct{.enum_one = first::IdenticallyNamed::VALUE0,
+                  .enum_two = second::IdenticallyNamed::VALUE3},
+      MultiStruct{.enum_one = first::IdenticallyNamed::VALUE1,
+                  .enum_two = second::IdenticallyNamed::VALUE4},
+      MultiStruct{.enum_one = first::IdenticallyNamed::VALUE2,
+                  .enum_two = second::IdenticallyNamed::VALUE5},
+  });
+
+  const auto conn = sqlite::connect();
+  conn.and_then(drop<MultiStruct> | if_exists);
+
+  write(conn, objects);
+
+  const auto read_objects =
+      sqlgen::read<std::vector<MultiStruct>>(conn).value();
+  std::vector<uint32_t> actual_ids;
+  for (const auto& obj : read_objects) {
+    if (obj.enum_one == first::IdenticallyNamed::VALUE0) {
+      EXPECT_EQ(obj.enum_two, second::IdenticallyNamed::VALUE3);
+    } else if (obj.enum_one == first::IdenticallyNamed::VALUE1) {
+      EXPECT_EQ(obj.enum_two, second::IdenticallyNamed::VALUE4);
+    } else if (obj.enum_one == first::IdenticallyNamed::VALUE2) {
+      EXPECT_EQ(obj.enum_two, second::IdenticallyNamed::VALUE5);
+    } else {
+      FAIL() << "Unexpected enum value";
+    }
+  }
+}
+
+}  // namespace test_enum_namespace
+
+#endif


### PR DESCRIPTION
This PR adds `sqlgen::Enum`. It uses `reflectcpp` to perform the string <-> int conversions to/from the DB interface. It uses the built-in enum types for mysql/postgres and string representation for sqlite by default. It allows using the underlying integer representation in all 3 cases.

I consider this a WIP so please feel free to suggest improvements. I for the life of me could not get a mysql/maria server running to test that part. I kept getting SSL certificate errors when trying to start a connection. If you have a docker-compose yml ready, I'd gladly test the mysql implementation as well.

This is the code I used for testing:
```cpp
#include <iostream>
#include <sqlgen.hpp>
#include <sqlgen/Enum.hpp>
#include <sqlgen/mysql.hpp>
#include <sqlgen/postgres.hpp>
#include <sqlgen/sqlite.hpp>

enum class TestEnum : int {
  TEST_VALUE1 = 1,
  TEST_VALUE2 = 2,
};

struct EnumTest {
  sqlgen::PrimaryKey<int, true> id;
  sqlgen::Enum<TestEnum> type;
  std::string name;
};

struct IntBasedTest {
  sqlgen::PrimaryKey<int, true> id;
  sqlgen::Enum<TestEnum, true> type;
  std::string name;
};

struct User {
  std::string name;
  int age;
};

int main() {
  EnumTest type_based;
  type_based.id = 1;
  type_based.type = TestEnum::TEST_VALUE1;
  type_based.name = "Test";

  const auto postgres_creds =
      sqlgen::postgres::Credentials{.user = "username",
                                    .password = "password",
                                    .host = "172.17.0.1",
                                    .dbname = "mydb",
                                    .port = 5432};

  auto postgres_conn = sqlgen::postgres::connect(postgres_creds);
  const auto mysql_creds =
      sqlgen::mysql::Credentials{.host = "172.17.0.1",
                                 .user = "myuser",
                                 .password = "mypassword",
                                 .dbname = "mydatabase",
                                 .port = 3306,
                                 .unix_socket = "/var/run/mysqld/mysqld.sock"};

  // Connect to a file-based database
  const auto sqlite_conn = sqlgen::sqlite::connect("database.db");

  IntBasedTest int_based;
  int_based.id = 1;
  int_based.type = TestEnum::TEST_VALUE2;
  int_based.name = "Test";
  // Connect to the database
  // const auto mysql_conn = sqlgen::mysql::connect(mysql_creds);

  // Create and insert a user
  sqlgen::write(postgres_conn, type_based);
  sqlgen::write(postgres_conn, int_based);
  sqlgen::write(sqlite_conn, type_based);
  sqlgen::write(sqlite_conn, int_based);

  // Read all users
  const auto postgres_items =
      sqlgen::read<std::vector<EnumTest>>(postgres_conn).value();
  const auto postgres_items2 =
      sqlgen::read<std::vector<IntBasedTest>>(postgres_conn).value();
  const auto sqlite_items =
      sqlgen::read<std::vector<EnumTest>>(sqlite_conn).value();
  const auto sqlite_items2 =
      sqlgen::read<std::vector<IntBasedTest>>(sqlite_conn).value();
  // const auto mysql_items =
  // sqlgen::read<std::vector<EnumTest>>(mysql_conn).value();

  auto print_rows = [](const auto& items, const std::string& db_name) {
    for (const auto& it : items) {
      std::cout << db_name << ": " << it.id.get() << ": name: " << it.name
                << ", uuid: " << "???" << ", type: " << it.type.str()
                << std::endl;
    }
    std::cout << "------------------------" << std::endl;
  };
  print_rows(postgres_items, "postgre:enum");
  print_rows(postgres_items2, "postgres:int-based-enum");
  print_rows(sqlite_items, "sqlite:enum");
  print_rows(sqlite_items2, "sqlite:int-based-enum");

  return 0;
}
```

One additional change I did was to switch the remote URL for vcpkg from `ssh` to `https`. This makes cloning the repo easier, IMO. I could make a separate PR for that, if you'd prefer to keep this one clean.