### PR TITLE
Fix memory management for postgres in edge cases

### DIFF
--- a/src/sqlgen/postgres/exec.cpp
+++ b/src/sqlgen/postgres/exec.cpp
@@ -9,7 +9,7 @@ namespace sqlgen::postgres {
 
 Result<Ref<PGresult>> exec(const Ref<PGconn>& _conn,
                            const std::string& _sql) noexcept {
-  const auto res = PQexec(_conn.get(), _sql.c_str());
+  auto res = PQexec(_conn.get(), _sql.c_str());
 
   const auto status = PQresultStatus(res);
 
@@ -18,6 +18,9 @@ Result<Ref<PGresult>> exec(const Ref<PGconn>& _conn,
     const auto err =
         error("Executing '" + _sql + "' failed: " + PQresultErrorMessage(res));
     PQclear(res);
+    while ((res = PQgetResult(_conn.get())) != nullptr)
+        PQclear(res);
+
     return err;
   }
 


### PR DESCRIPTION
Hi sqlgen developers,

As discussed in [1], I encountered some issues with memory management for Postgres in v0.3.0 and v0.4.0. If you recall, I had created a patch [2] to fix those problems. When I tried to raise a PR I noticed ```main``` has moved on a fair bit since then, so some parts of the patch are no longer needed and those that still apply needed some changes. At any rate, I updated the patch to fix the current state of ```main```, which this PR contains for your perusal.

With regards to RAII: the code is a tad complex and I am by no means an expert in libpq, so I'm afraid I was not brave enough to attempt implementing this as you had suggested in the discussion (a-la [3]). At any rate, even if you embark on such a clean up, I think it's still best to apply some version of this patch since it at least solves the immediate problems and makes the "correct fix" slightly less urgent.

One final point: You may find the ```ROLLBACK``` a bit puzzling. I added it on the advice of Gemini, as follows (verbatim):

> # 2. Missing Transaction Cleanup in insert_impl()
>
> If insert_impl() is called within a PostgreSQL transaction, an error during the PREPARE or the row insertions should cause the transaction to be rolled back. The current implementation only deallocates the prepared statement (DEALLOCATE).
> 
> ```C++
>
> // On error (e.g., lines 72, 80, 98), you should consider:
> execute("ROLLBACK;");
> execute("DEALLOCATE sqlgen_insert_into_table;"); // If applicable
> ```
> While not strictly a memory leak, it's a critical resource/state management issue. If the function fails, the caller is left with a half-executed and possibly failed transaction, which could lock resources or lead to inconsistent data unless the caller explicitly handles the rollback (which good RAII wrappers often try to handle internally).

[1] https://github.com/getml/sqlgen/issues/88
[2] [Proposed fix to this round of leaks](https://github.com/getml/sqlgen/issues/88#issuecomment-3526722029)
[3] [DuckDBResult.hpp](https://github.com/getml/sqlgen/blob/f/duckdb/include/sqlgen/duckdb/DuckDBResult.hpp)