### PR TITLE
Add PostgreSQL notice processor support

### DIFF
--- a/include/sqlgen/postgres/Credentials.hpp
+++ b/include/sqlgen/postgres/Credentials.hpp
@@ -1,6 +1,7 @@
 #ifndef SQLGEN_POSTGRES_CREDENTIALS_HPP_
 #define SQLGEN_POSTGRES_CREDENTIALS_HPP_
 
+#include <functional>
 #include <string>
 
 namespace sqlgen::postgres {
@@ -11,6 +12,7 @@ struct Credentials {
   std::string host;
   std::string dbname;
   int port = 5432;
+  std::function<void(const char*)> notice_handler;
 
   std::string to_str() const {
     return "postgresql://" + user + ":" + password + "@" + host + ":" +

--- a/include/sqlgen/postgres/PostgresV2Connection.hpp
+++ b/include/sqlgen/postgres/PostgresV2Connection.hpp
@@ -3,6 +3,7 @@
 
 #include <libpq-fe.h>
 
+#include <functional>
 #include <memory>
 #include <rfl.hpp>
 #include <stdexcept>
@@ -15,14 +16,21 @@ namespace sqlgen::postgres {
 
 class SQLGEN_API PostgresV2Connection {
  public:
+  using NoticeHandler = std::function<void(const char*)>;
+
   PostgresV2Connection(PGconn* _ptr)
       : ptr_(Ref<PGconn>::make(std::shared_ptr<PGconn>(_ptr, &PQfinish))
                  .value()) {}
+
+  PostgresV2Connection(PGconn* _ptr, NoticeHandler _notice_handler);
 
   ~PostgresV2Connection() = default;
 
   static rfl::Result<PostgresV2Connection> make(
       const std::string& _conn_str) noexcept;
+
+  static rfl::Result<PostgresV2Connection> make(
+      const std::string& _conn_str, NoticeHandler _notice_handler) noexcept;
 
   static rfl::Result<PostgresV2Connection> make(PGconn* _ptr) noexcept {
     try {
@@ -37,6 +45,7 @@ class SQLGEN_API PostgresV2Connection {
 
  private:
   Ref<PGconn> ptr_;
+  std::shared_ptr<NoticeHandler> notice_handler_;
 };
 
 }  // namespace sqlgen::postgres

--- a/src/sqlgen/postgres/Connection.cpp
+++ b/src/sqlgen/postgres/Connection.cpp
@@ -16,7 +16,9 @@ namespace sqlgen::postgres {
 Connection::Connection(const Conn& _conn) : conn_(_conn) {}
 
 Connection::Connection(const Credentials& _credentials)
-    : conn_(PostgresV2Connection::make(_credentials.to_str()).value()) {}
+    : conn_(PostgresV2Connection::make(_credentials.to_str(),
+                                       _credentials.notice_handler)
+                .value()) {}
 
 Result<Nothing> Connection::begin_transaction() noexcept {
   return execute("BEGIN TRANSACTION;");
@@ -182,7 +184,8 @@ Result<Nothing> Connection::insert_impl(
 
 rfl::Result<Ref<Connection>> Connection::make(
     const Credentials& _credentials) noexcept {
-  return PostgresV2Connection::make(_credentials.to_str())
+  return PostgresV2Connection::make(_credentials.to_str(),
+                                    _credentials.notice_handler)
       .transform([](auto&& _conn) { return Ref<Connection>::make(_conn); });
 }
 

--- a/src/sqlgen/postgres/PostgresV2Connection.cpp
+++ b/src/sqlgen/postgres/PostgresV2Connection.cpp
@@ -2,6 +2,28 @@
 
 namespace sqlgen::postgres {
 
+namespace {
+void notice_trampoline(void* arg, const char* message) {
+  auto* handler =
+      static_cast<PostgresV2Connection::NoticeHandler*>(arg);
+  if (handler && *handler) {
+    (*handler)(message);
+  }
+}
+}  // namespace
+
+PostgresV2Connection::PostgresV2Connection(PGconn* _ptr,
+                                           NoticeHandler _notice_handler)
+    : ptr_(Ref<PGconn>::make(std::shared_ptr<PGconn>(_ptr, &PQfinish)).value()),
+      notice_handler_(_notice_handler
+                          ? std::make_shared<NoticeHandler>(
+                                std::move(_notice_handler))
+                          : nullptr) {
+  if (notice_handler_) {
+    PQsetNoticeProcessor(ptr_.get(), notice_trampoline, notice_handler_.get());
+  }
+}
+
 rfl::Result<PostgresV2Connection> PostgresV2Connection::make(
     const std::string& _conn_str) noexcept {
   auto conn = PQconnectdb(_conn_str.c_str());
@@ -12,6 +34,18 @@ rfl::Result<PostgresV2Connection> PostgresV2Connection::make(
     return error(msg);
   }
   return PostgresV2Connection(conn);
+}
+
+rfl::Result<PostgresV2Connection> PostgresV2Connection::make(
+    const std::string& _conn_str, NoticeHandler _notice_handler) noexcept {
+  auto conn = PQconnectdb(_conn_str.c_str());
+  if (PQstatus(conn) != CONNECTION_OK) {
+    const auto msg =
+        std::string("Connection to postgres failed: ") + PQerrorMessage(conn);
+    PQfinish(conn);
+    return error(msg);
+  }
+  return PostgresV2Connection(conn, std::move(_notice_handler));
 }
 
 }  // namespace sqlgen::postgres

--- a/tests/postgres/test_notice_processor.cpp
+++ b/tests/postgres/test_notice_processor.cpp
@@ -1,0 +1,109 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <mutex>
+#include <sqlgen/postgres.hpp>
+#include <string>
+#include <vector>
+
+namespace test_notice_processor {
+
+TEST(postgres, notice_processor_captures_raise_notice) {
+  std::vector<std::string> captured_notices;
+  std::mutex mtx;
+
+  const auto credentials = sqlgen::postgres::Credentials{
+      .user = "postgres",
+      .password = "password",
+      .host = "localhost",
+      .dbname = "postgres",
+      .notice_handler = [&](const char* msg) {
+        std::lock_guard<std::mutex> lock(mtx);
+        captured_notices.push_back(msg);
+      }};
+
+  auto conn_result = sqlgen::postgres::connect(credentials);
+  ASSERT_TRUE(conn_result);
+  auto conn = conn_result.value();
+
+  // Execute a DO block that raises a notice
+  auto result = conn->execute(R"(
+    DO $$
+    BEGIN
+      RAISE NOTICE 'Hello from PL/pgSQL';
+    END
+    $$;
+  )");
+  ASSERT_TRUE(result) << result.error().what();
+
+  // Verify notice was captured
+  std::lock_guard<std::mutex> lock(mtx);
+  ASSERT_EQ(captured_notices.size(), 1);
+  EXPECT_TRUE(captured_notices[0].find("Hello from PL/pgSQL") !=
+              std::string::npos);
+}
+
+TEST(postgres, no_notice_handler_works) {
+  // Default behavior - no handler, should not crash
+  const auto credentials = sqlgen::postgres::Credentials{
+      .user = "postgres",
+      .password = "password",
+      .host = "localhost",
+      .dbname = "postgres"};
+
+  auto conn_result = sqlgen::postgres::connect(credentials);
+  ASSERT_TRUE(conn_result);
+  auto conn = conn_result.value();
+
+  auto result = conn->execute(R"(
+    DO $$
+    BEGIN
+      RAISE NOTICE 'This goes to stderr by default';
+    END
+    $$;
+  )");
+  ASSERT_TRUE(result);
+}
+
+TEST(postgres, notice_processor_multiple_notices) {
+  std::vector<std::string> captured_notices;
+  std::mutex mtx;
+
+  const auto credentials = sqlgen::postgres::Credentials{
+      .user = "postgres",
+      .password = "password",
+      .host = "localhost",
+      .dbname = "postgres",
+      .notice_handler = [&](const char* msg) {
+        std::lock_guard<std::mutex> lock(mtx);
+        captured_notices.push_back(msg);
+      }};
+
+  auto conn_result = sqlgen::postgres::connect(credentials);
+  ASSERT_TRUE(conn_result);
+  auto conn = conn_result.value();
+
+  // Execute a DO block that raises multiple notices
+  auto result = conn->execute(R"(
+    DO $$
+    BEGIN
+      RAISE NOTICE 'First notice';
+      RAISE NOTICE 'Second notice';
+      RAISE NOTICE 'Third notice';
+    END
+    $$;
+  )");
+  ASSERT_TRUE(result) << result.error().what();
+
+  // Verify all notices were captured
+  std::lock_guard<std::mutex> lock(mtx);
+  ASSERT_EQ(captured_notices.size(), 3);
+  EXPECT_TRUE(captured_notices[0].find("First notice") != std::string::npos);
+  EXPECT_TRUE(captured_notices[1].find("Second notice") != std::string::npos);
+  EXPECT_TRUE(captured_notices[2].find("Third notice") != std::string::npos);
+}
+
+}  // namespace test_notice_processor
+
+#endif


### PR DESCRIPTION
## Summary

- Add optional `notice_handler` callback to `Credentials` for capturing PostgreSQL `RAISE NOTICE` messages
- Store handler in `PostgresV2Connection` with stable lifetime using `shared_ptr`
- Preserve libpq's default stderr behavior when no handler is provided

## Test plan

- [x] `notice_processor_captures_raise_notice` - verifies handler captures notices
- [x] `no_notice_handler_works` - verifies default stderr behavior without handler
- [x] `notice_processor_multiple_notices` - verifies multiple notices captured in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)