### PR TITLE
Add parameterized execute for postgres

### DIFF
--- a/include/sqlgen/postgres/PostgresV2Result.hpp
+++ b/include/sqlgen/postgres/PostgresV2Result.hpp
@@ -25,6 +25,10 @@ class SQLGEN_API PostgresV2Result {
   static rfl::Result<PostgresV2Result> make(
       const std::string& _query, const PostgresV2Connection& _conn) noexcept;
 
+  static rfl::Result<PostgresV2Result> make(
+      const std::string& _query, const PostgresV2Connection& _conn,
+      const std::vector<std::optional<std::string>>& _params) noexcept;
+
   static rfl::Result<PostgresV2Result> make(PGresult* _ptr) noexcept {
     try {
       return PostgresV2Result(_ptr);

--- a/src/sqlgen/postgres/Connection.cpp
+++ b/src/sqlgen/postgres/Connection.cpp
@@ -32,6 +32,14 @@ Result<Nothing> Connection::execute(const std::string& _sql) noexcept {
   });
 }
 
+Result<Nothing> Connection::execute_params(
+    const std::string& _sql,
+    const std::vector<std::optional<std::string>>& _params) noexcept {
+  return PostgresV2Result::make(_sql, conn_, _params).transform([](auto&&) {
+    return Nothing{};
+  });
+}
+
 Result<Nothing> Connection::end_write() {
   if (PQputCopyEnd(conn_.ptr(), NULL) == -1) {
     return error(PQerrorMessage(conn_.ptr()));

--- a/src/sqlgen/postgres/PostgresV2Result.cpp
+++ b/src/sqlgen/postgres/PostgresV2Result.cpp
@@ -1,10 +1,38 @@
 #include "sqlgen/postgres/PostgresV2Connection.hpp"
+#include "sqlgen/postgres/PostgresV2Result.hpp"
 
 namespace sqlgen::postgres {
 
 rfl::Result<PostgresV2Result> PostgresV2Result::make(
     const std::string& _query, const PostgresV2Connection& _conn) noexcept {
   auto res = PQexec(_conn.ptr(), _query.c_str());
+  const auto status = PQresultStatus(res);
+  if (status != PGRES_COMMAND_OK && status != PGRES_TUPLES_OK &&
+      status != PGRES_COPY_IN) {
+    const auto msg =
+        std::string("Query execution failed: ") + PQerrorMessage(_conn.ptr());
+    PQclear(res);
+    return error(msg);
+  }
+  return PostgresV2Result(res);
+}
+
+rfl::Result<PostgresV2Result> PostgresV2Result::make(
+    const std::string& _query, const PostgresV2Connection& _conn,
+    const std::vector<std::optional<std::string>>& _params) noexcept {
+  std::vector<const char*> param_values(_params.size());
+  for (size_t i = 0; i < _params.size(); ++i) {
+    param_values[i] = _params[i] ? _params[i]->c_str() : nullptr;
+  }
+
+  auto res = PQexecParams(_conn.ptr(), _query.c_str(),
+                          static_cast<int>(_params.size()),
+                          nullptr,             // paramTypes (let server infer)
+                          param_values.data(), // paramValues
+                          nullptr,             // paramLengths (text format)
+                          nullptr,             // paramFormats (text format)
+                          0);                  // resultFormat (text)
+
   const auto status = PQresultStatus(res);
   if (status != PGRES_COMMAND_OK && status != PGRES_TUPLES_OK &&
       status != PGRES_COPY_IN) {

--- a/tests/postgres/test_execute_params.cpp
+++ b/tests/postgres/test_execute_params.cpp
@@ -1,0 +1,141 @@
+#ifndef SQLGEN_BUILD_DRY_TESTS_ONLY
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <sqlgen/postgres.hpp>
+#include <string>
+
+namespace test_execute_params {
+
+TEST(postgres, execute_with_string_params) {
+  const auto credentials = sqlgen::postgres::Credentials{
+      .user = "postgres",
+      .password = "password",
+      .host = "localhost",
+      .dbname = "postgres"};
+  auto conn_result = sqlgen::postgres::connect(credentials);
+  ASSERT_TRUE(conn_result);
+  auto conn = conn_result.value();
+
+  // Create a test table
+  auto create_result = conn->execute(R"(
+    CREATE TABLE IF NOT EXISTS test_execute_params (
+      id SERIAL PRIMARY KEY,
+      name TEXT,
+      value INTEGER
+    );
+  )");
+  ASSERT_TRUE(create_result) << create_result.error().what();
+
+  // Clean up any existing data
+  auto truncate_result = conn->execute("TRUNCATE test_execute_params;");
+  ASSERT_TRUE(truncate_result) << truncate_result.error().what();
+
+  // Insert using parameterized execute
+  auto insert_result = conn->execute(
+      "INSERT INTO test_execute_params (name, value) VALUES ($1, $2);",
+      std::string("test_name"), 42);
+  ASSERT_TRUE(insert_result) << insert_result.error().what();
+
+  // Clean up
+  auto drop_result = conn->execute("DROP TABLE test_execute_params;");
+  ASSERT_TRUE(drop_result) << drop_result.error().what();
+}
+
+TEST(postgres, execute_with_null_param) {
+  const auto credentials = sqlgen::postgres::Credentials{
+      .user = "postgres",
+      .password = "password",
+      .host = "localhost",
+      .dbname = "postgres"};
+  auto conn_result = sqlgen::postgres::connect(credentials);
+  ASSERT_TRUE(conn_result);
+  auto conn = conn_result.value();
+
+  // Create a test table
+  auto create_result = conn->execute(R"(
+    CREATE TABLE IF NOT EXISTS test_execute_null (
+      id SERIAL PRIMARY KEY,
+      name TEXT
+    );
+  )");
+  ASSERT_TRUE(create_result) << create_result.error().what();
+
+  // Insert with null parameter using std::optional
+  std::optional<std::string> null_val = std::nullopt;
+  auto insert_result = conn->execute(
+      "INSERT INTO test_execute_null (name) VALUES ($1);", null_val);
+  ASSERT_TRUE(insert_result) << insert_result.error().what();
+
+  // Clean up
+  auto drop_result = conn->execute("DROP TABLE test_execute_null;");
+  ASSERT_TRUE(drop_result) << drop_result.error().what();
+}
+
+TEST(postgres, execute_with_numeric_params) {
+  const auto credentials = sqlgen::postgres::Credentials{
+      .user = "postgres",
+      .password = "password",
+      .host = "localhost",
+      .dbname = "postgres"};
+  auto conn_result = sqlgen::postgres::connect(credentials);
+  ASSERT_TRUE(conn_result);
+  auto conn = conn_result.value();
+
+  // Create a test table
+  auto create_result = conn->execute(R"(
+    CREATE TABLE IF NOT EXISTS test_execute_numeric (
+      id SERIAL PRIMARY KEY,
+      int_val INTEGER,
+      float_val DOUBLE PRECISION,
+      bool_val BOOLEAN
+    );
+  )");
+  ASSERT_TRUE(create_result) << create_result.error().what();
+
+  // Insert with various numeric types
+  auto insert_result = conn->execute(
+      "INSERT INTO test_execute_numeric (int_val, float_val, bool_val) "
+      "VALUES ($1, $2, $3);",
+      123, 3.14159, true);
+  ASSERT_TRUE(insert_result) << insert_result.error().what();
+
+  // Clean up
+  auto drop_result = conn->execute("DROP TABLE test_execute_numeric;");
+  ASSERT_TRUE(drop_result) << drop_result.error().what();
+}
+
+TEST(postgres, execute_call_function) {
+  const auto credentials = sqlgen::postgres::Credentials{
+      .user = "postgres",
+      .password = "password",
+      .host = "localhost",
+      .dbname = "postgres"};
+  auto conn_result = sqlgen::postgres::connect(credentials);
+  ASSERT_TRUE(conn_result);
+  auto conn = conn_result.value();
+
+  // Create a simple test function
+  auto create_fn_result = conn->execute(R"(
+    CREATE OR REPLACE FUNCTION test_add(a INTEGER, b INTEGER)
+    RETURNS INTEGER AS $$
+    BEGIN
+      RETURN a + b;
+    END;
+    $$ LANGUAGE plpgsql;
+  )");
+  ASSERT_TRUE(create_fn_result) << create_fn_result.error().what();
+
+  // Call the function with parameters
+  auto call_result = conn->execute("SELECT test_add($1, $2);", 5, 3);
+  ASSERT_TRUE(call_result) << call_result.error().what();
+
+  // Clean up
+  auto drop_fn_result = conn->execute("DROP FUNCTION test_add;");
+  ASSERT_TRUE(drop_fn_result) << drop_fn_result.error().what();
+}
+
+}  // namespace test_execute_params
+
+#endif


### PR DESCRIPTION
## Summary

Add support for parameterized queries using PostgreSQL's `$1, $2, ...` placeholder syntax. This enables safe parameter binding for:

- Calling PostgreSQL functions without defining custom types
- Executing dynamic queries with SQL injection protection
- Passing NULL values via `std::optional` or `std::nullopt`

### API

```cpp
// Variadic execute with automatic type conversion
conn->execute("SELECT my_func($1, $2)", tenant_id, user_email);

// Supported types: string, numeric, bool, optional, nullptr
conn->execute("INSERT INTO t (a, b, c) VALUES ($1, $2, $3)",
              std::string("text"), 42, std::nullopt);
```

### Implementation

- Add `PostgresV2Result::make()` overload using `PQexecParams`
- Add variadic `execute()` template to `Connection` with `to_param()` helper
- Internal `execute_params()` method handles the actual libpq call

## Test plan

- [x] `execute_with_string_params` - string and int parameters
- [x] `execute_with_null_param` - NULL via `std::optional`
- [x] `execute_with_numeric_params` - int, double, bool
- [x] `execute_call_function` - calling PL/pgSQL function

🤖 Generated with [Claude Code](https://claude.com/claude-code)